### PR TITLE
Async mapping improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@
 -   Features
 -   Bug Fixes
 
+## v0.3.3
+
+- Bug Fixes
+  - fix an issue with the `mergeMap`, `switchMap`, and `concatMap`
+    - when used while piping from a `PassThrough` `end` signals would prematurely cause the stream to close.
+    - this change removes a hack that explicitly sets the `ended` state of the output stream to `false`, this was a bad idea
+    - `end` events are now controlled explicitly within each of the `maps`. 
+
 ## v0.3.2
 
 - Bug Fixes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@trivago/samsa",
-  "version": "0.3.0",
+  "version": "0.3.0-beta1",
   "types": "lib/index.d.ts",
   "main": "lib/index.js",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@trivago/samsa",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "types": "lib/index.d.ts",
   "main": "lib/index.js",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@trivago/samsa",
-  "version": "0.3.0-beta1",
+  "version": "0.3.1-beta1",
   "types": "lib/index.d.ts",
   "main": "lib/index.js",
   "license": "MIT",

--- a/src/creators/from.ts
+++ b/src/creators/from.ts
@@ -18,9 +18,9 @@ export const from = <T extends any>(
         });
     }
 
-    if (Readable.hasOwnProperty("from")) {
-        return Readable.from(ish);
-    }
+    // if (Readable.hasOwnProperty("from")) {
+    //     return Readable.from(ish);
+    // }
     return new ObjectReadable({
         read() {
             for (const value of ish) {

--- a/src/operators/concatMap.ts
+++ b/src/operators/concatMap.ts
@@ -30,7 +30,18 @@ export const concatMap = (project: (t: any) => Readable) => {
             next();
         }
     });
-
+    
+    /**
+     * What is happening here?
+     *
+     * This is in response to a bug where if, for whatever reason, you were piping a
+     * PipeThrough stream into a mergeMap, the end event would fire well before it should.
+     *
+     * So, we are redirecting the input source and explicitly telling it not to pass end
+     * down the stream. This allows us to explicitly call end when we want to. See line 20. If
+     * we still have streams in our register, we need to continue getting the data from them,
+     * but if one of them ends, it will cause `out` to also end. This prevents that.
+     */
     const redirectedInput = new PassThrough({ objectMode: true });
 
     redirectedInput.pipe(out);

--- a/src/operators/mergeMap.ts
+++ b/src/operators/mergeMap.ts
@@ -1,12 +1,11 @@
-import { Readable, TransformCallback } from "stream";
-import { ObjectReadable } from "../utils/ObjectReadable";
+import { Readable, TransformCallback, PassThrough } from "stream";
 import { ObjectTransform } from "../utils/ObjectTransform";
 
 export const mergeMap = (project: (t: any) => Readable) => {
     let streamRegister: Readable[] = [];
 
     const out = new ObjectTransform({
-        transform(data, _: any, next: TransformCallback) {
+        transform(data: any, _: any, next: TransformCallback) {
             const reader = project(data);
 
             streamRegister.push(reader);
@@ -17,6 +16,9 @@ export const mergeMap = (project: (t: any) => Readable) => {
 
             reader.on("end", () => {
                 streamRegister = streamRegister.filter(i => i !== reader);
+                if (streamRegister.length === 0) {
+                    this.push(null);
+                }
             });
 
             reader.on("error", err => {
@@ -27,34 +29,27 @@ export const mergeMap = (project: (t: any) => Readable) => {
         }
     });
 
+    /**
+     * What is happening here?
+     *
+     * This is in response to a bug where if, for whatever reason, you were piping a
+     * PipeThrough stream into a mergeMap, the end event would fire well before it should.
+     *
+     * So, we are redirecting the input source and explicitly telling it not to pass end
+     * down the stream. This allows us to explicitly call end when we want to. See line 20. If
+     * we still have streams in our register, we need to continue getting the data from them,
+     * but if one of them ends, it will cause `out` to also end. This prevents that.
+     */
+    const redirectedInput = new PassThrough({ objectMode: true });
+
+    redirectedInput.pipe(out);
+
     out.on("pipe", source => {
-        source.on("end", () => {
-            /**
-             * I'm so sorry.
-             *
-             * What the hell is happening here?
-             *
-             * This is a hack that prevents our source from forcing
-             * our downstream to end. The problem is that if our source
-             * stream ends while our stream register is still full, the
-             * output stream will error out without emitting the remaining
-             * values
-             *
-             * Example:
-             *
-             * range(0,20)
-             *   .pipe(
-             *      mergeMap(n => range(0,20))
-             *   )
-             *
-             * This should output 0..20 20 times. Without the below hack, this
-             * will fail once the first range is finished.
-             */
-            // @ts-ignore
-            out._readableState.ended = false;
-            // @ts-ignore
-            out._writableState.ended = false;
-        });
+        source.unpipe(out);
+        source.pipe(
+            redirectedInput,
+            { end: false }
+        );
     });
 
     return out;

--- a/src/operators/switchMap.ts
+++ b/src/operators/switchMap.ts
@@ -40,7 +40,18 @@ export const switchMap = (project: (t: any) => Readable) => {
             return next();
         }
     });
-
+    
+    /**
+     * What is happening here?
+     *
+     * This is in response to a bug where if, for whatever reason, you were piping a
+     * PipeThrough stream into a mergeMap, the end event would fire well before it should.
+     *
+     * So, we are redirecting the input source and explicitly telling it not to pass end
+     * down the stream. This allows us to explicitly call end when we want to. See line 20. If
+     * we still have streams in our register, we need to continue getting the data from them,
+     * but if one of them ends, it will cause `out` to also end. This prevents that.
+     */
     const redirectedInput = new PassThrough({ objectMode: true });
 
     redirectedInput.pipe(out);


### PR DESCRIPTION
Update async mapping (`concatMap`, `switchMap`, and `mergeMap`) to remove reliance on directly interfering with state.